### PR TITLE
Remove .presentationDetents([.medium]) for under iOS 16 support 

### DIFF
--- a/urlscheme share/ContentView.swift
+++ b/urlscheme share/ContentView.swift
@@ -53,7 +53,6 @@ struct ContentView: View {
                     }
                     .sheet(isPresented: $isShowingShareSheet) {
                         ActivityView(activityItems: [textToShare])
-                            .presentationDetents([.medium])
                     }
                 }
                 .padding()


### PR DESCRIPTION
It is targeted to iOS 16+ devices which is not possible to build in iOS 15
You can use basic sheet mode for various versions 